### PR TITLE
Fix bug: while condition in merge function

### DIFF
--- a/src/main/scala/lectures/algorithms/MergeSort.scala
+++ b/src/main/scala/lectures/algorithms/MergeSort.scala
@@ -55,7 +55,7 @@ object MergeSort {
         i += 1
         left += 1
       }
-      while (right < mid) {
+      while (right < until) {
         dst(i) = src(right)
         i += 1
         right += 1


### PR DESCRIPTION
Find and fix A small bug in merge function.

BTW. I think the `copy` operation is redundant and erroneous.

Consider the code in the `sort` function, if we always pick an even number as `maxDepth`, then `src` will be `ys` and `dst` will be `xs`. Basically, it will merge 2 sorted array slices from `ys` to `xs`. Thus, no `copy` operation is needed here. => **redundant**

``` scala
val flip = (maxDepth - depth) % 2 == 0
val src = if (flip) ys else xs
val dst = if (flip) xs else ys
merge(src, dst, from, mid, until)
```

One more `copy` will even lead to the wrong answer, since at depth 0 with an even `maxDepht`, `xs` is the sorted array,`ys` is not but an array with 2 sorted slices. Copying ys to `xs` is apparently a wrong operation. => **erroneous**

Consider the following code after merging this pull request

``` scala
val xs = Random.shuffle(1 to 10).toArray
parMergeSort(xs, 2)
println(xs.toList) // List(1, 4, 7, 8, 9, 2, 3, 5, 6, 10)
```

A naive workaround could be force `MaxDepth` to a even number, thus `xs` will be sorted after calling `sort`.

Finally, I really appreciate your work on this repo. It is very helpful. Thank you.
